### PR TITLE
fix: bump Android compileSdk to 36 for AGP 9 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.bazle.vpn_connection_detector'
-    compileSdk 34
+    compileSdk 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
### Problem
This plugin's Android module compiles against `compileSdk = 34`, while its dependency `connectivity_plus` already requires `compileSdk 36`. Under **Android Gradle Plugin 9**, the strict `checkDebugAarMetadata` task fails the build with an error like:

> Dependency 'connectivity_plus' requires libraries and applications that depend on it to compile against version 36 or later of the Android APIs.

This blocks any app building on AGP 9 (Flutter's upcoming default) that uses this plugin.

### Fix
Bump `compileSdk` from 34 to 36 in `android/build.gradle`. One-line change, no API impact.

### Environment
- Flutter 3.44 (stable), AGP 9.x, Gradle 9.x, JDK 21
- vpn_connection_detector 2.0.3, connectivity_plus 7.x